### PR TITLE
Update DQM folder name and ES collector host

### DIFF
--- a/dqmControl.sh
+++ b/dqmControl.sh
@@ -10,7 +10,7 @@ if [ $1 = "start" ]; then
 	exit
     fi
 
-    screen -d -m -S onlineDQM $HOME/DQM.new/p5tools/runOnlineDQM.sh $2 $3
+    screen -d -m -S onlineDQM $HOME/DQM/p5tools/runOnlineDQM.sh $2 $3
 
 elif [ $1 = "stop" ]; then
 

--- a/ecaldqmconfig.py
+++ b/ecaldqmconfig.py
@@ -22,7 +22,7 @@ class ConfigNode:
 
 config = ConfigNode()
 
-config.workdir = '/nfshome0/ecalpro/DQM.new/p5tools'
+config.workdir = '/nfshome0/ecalpro/DQM/p5tools'
 
 config.period = 'Run2016'
 
@@ -32,10 +32,10 @@ config.tmpoutdir = '/data/dqm-data/tmp'
 
 config.dbwrite = ConfigNode()
 if TEST:
-    config.dbwrite.readFile('/nfshome0/ecalpro/DQM.new/.ecal_db_test.conf')
+    config.dbwrite.readFile('/nfshome0/ecalpro/DQM/.ecal_db_test.conf')
 else:
-    config.dbwrite.readFile('/nfshome0/ecalpro/DQM.new/.ecal_db_prod.conf')
+    config.dbwrite.readFile('/nfshome0/ecalpro/DQM/.ecal_db_prod.conf')
 
 config.dbread = ConfigNode()
-config.dbread.readFile('/nfshome0/ecalpro/DQM.new/.ecal_db_read.conf')
+config.dbread.readFile('/nfshome0/ecalpro/DQM/.ecal_db_read.conf')
 

--- a/es_dqm_sourceclient-privlive_cfg.py
+++ b/es_dqm_sourceclient-privlive_cfg.py
@@ -133,7 +133,8 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.ecalPreshowerRawDataTask.FEDRawDataCollection = cms.InputTag("rawDataRepacker")
 
 # HACK Aug 9 yiiyama
-process.source.minEventsPerLumi = 1000
+#process.source.minEventsPerLumi = 1000
+process.source.minEventsPerLumi = cms.untracked.int32(-1)
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)

--- a/es_dqm_sourceclient-privlive_cfg.py
+++ b/es_dqm_sourceclient-privlive_cfg.py
@@ -95,7 +95,7 @@ process.dqmSaver.convention = "Offline"
 process.dqmSaver.producer = "DQM"
 
 process.DQM.collectorPort = 9190
-process.DQM.collectorHost = "ecalod-web01.cms"
+process.DQM.collectorHost = "fu-c2f11-21-02"
 ##### EDIT yiiyama Aug 08 2014
 
 process.load("DQM.EcalPreshowerMonitorModule.EcalPreshowerMonitorTasks_cfi")

--- a/onlineDQM.py
+++ b/onlineDQM.py
@@ -178,13 +178,13 @@ def startDQM(run, startLumi, daq, dqmRunKey, ecalIn, esIn, logFile):
 #            logFile.write(command)
 #            procs['Calibration'] = (proc, log)
 
-        if esIn:
-            log = open(config.logdir + '/es_dqm_sourceclient-privlive_cfg.log', 'a')
-            log.write('\n\n\n')
-            command = 'source $HOME/DQM/cmssw.sh; exec cmsRun {conf} {common}'.format(conf = config.workdir + '/es_dqm_sourceclient-privlive_cfg.py', common = commonOptions)
-            proc = subprocess.Popen(command, shell = True, stdout = log, stderr = subprocess.STDOUT)
-            logFile.write(command)
-            procs['ES'] = (proc, log)
+#        if esIn:
+#            log = open(config.logdir + '/es_dqm_sourceclient-privlive_cfg.log', 'a')
+#            log.write('\n\n\n')
+#            command = 'source $HOME/DQM/cmssw.sh; exec cmsRun {conf} {common}'.format(conf = config.workdir + '/es_dqm_sourceclient-privlive_cfg.py', common = commonOptions)
+#            proc = subprocess.Popen(command, shell = True, stdout = log, stderr = subprocess.STDOUT)
+#            logFile.write(command)
+#            procs['ES'] = (proc, log)
 
     elif daq == 'minidaq':
         if not os.path.isdir('/dqmminidaq/run%d' % run):

--- a/onlineDQM.py
+++ b/onlineDQM.py
@@ -166,14 +166,14 @@ def startDQM(run, startLumi, daq, dqmRunKey, ecalIn, esIn, logFile):
 #
 #            log = open(config.logdir + '/ecal_dqm_sourceclient-privlive_cfg.log', 'a')
 #            log.write('\n\n\n')
-#            command = 'source $HOME/DQM.new/cmssw.sh; exec cmsRun {conf} {common} {ecal} {spec}'.format(conf = config.workdir + '/ecalConfigBuilder.py', common = commonOptions, ecal = ecalOptions, spec = 'cfgType=Physics')
+#            command = 'source $HOME/DQM/cmssw.sh; exec cmsRun {conf} {common} {ecal} {spec}'.format(conf = config.workdir + '/ecalConfigBuilder.py', common = commonOptions, ecal = ecalOptions, spec = 'cfgType=Physics')
 #            proc = subprocess.Popen(command, shell = True, stdout = log, stderr = subprocess.STDOUT)
 #            logFile.write(command)
 #            procs['Physics'] = (proc, log)
     
 #            log = open(config.logdir + '/ecalcalib_dqm_sourceclient-privlive_cfg.log', 'a')
 #            log.write('\n\n\n')
-#            command = 'source $HOME/DQM.new/cmssw.sh; exec cmsRun {conf} {common} {ecal} {spec}'.format(conf = config.workdir + '/ecalConfigBuilder.py', common = commonOptions, ecal = ecalOptions, spec = 'cfgType=Calibration')
+#            command = 'source $HOME/DQM/cmssw.sh; exec cmsRun {conf} {common} {ecal} {spec}'.format(conf = config.workdir + '/ecalConfigBuilder.py', common = commonOptions, ecal = ecalOptions, spec = 'cfgType=Calibration')
 #            proc = subprocess.Popen(command, shell = True, stdout = log, stderr = subprocess.STDOUT)
 #            logFile.write(command)
 #            procs['Calibration'] = (proc, log)
@@ -181,7 +181,7 @@ def startDQM(run, startLumi, daq, dqmRunKey, ecalIn, esIn, logFile):
         if esIn:
             log = open(config.logdir + '/es_dqm_sourceclient-privlive_cfg.log', 'a')
             log.write('\n\n\n')
-            command = 'source $HOME/DQM.new/cmssw.sh; exec cmsRun {conf} {common}'.format(conf = config.workdir + '/es_dqm_sourceclient-privlive_cfg.py', common = commonOptions)
+            command = 'source $HOME/DQM/cmssw.sh; exec cmsRun {conf} {common}'.format(conf = config.workdir + '/es_dqm_sourceclient-privlive_cfg.py', common = commonOptions)
             proc = subprocess.Popen(command, shell = True, stdout = log, stderr = subprocess.STDOUT)
             logFile.write(command)
             procs['ES'] = (proc, log)
@@ -199,7 +199,7 @@ def startDQM(run, startLumi, daq, dqmRunKey, ecalIn, esIn, logFile):
             
             log = open(config.logdir + '/ecalcalib_dqm_sourceclient-privlive_cfg.log', 'a')
             log.write('\n\n\n')
-            command = 'source $HOME/DQM.new/cmssw.sh; exec cmsRun {conf} {common} {ecal} {spec}'.format(conf = config.workdir + '/ecalConfigBuilder.py', common = commonOptions, ecal = ecalOptions, spec = 'cfgType=CalibrationStandalone')
+            command = 'source $HOME/DQM/cmssw.sh; exec cmsRun {conf} {common} {ecal} {spec}'.format(conf = config.workdir + '/ecalConfigBuilder.py', common = commonOptions, ecal = ecalOptions, spec = 'cfgType=CalibrationStandalone')
             proc = subprocess.Popen(command, shell = True, stdout = log, stderr = subprocess.STDOUT)
             logFile.write(command)
             procs['Calibration'] = (proc, log)
@@ -207,7 +207,7 @@ def startDQM(run, startLumi, daq, dqmRunKey, ecalIn, esIn, logFile):
         if esIn:
             log = open(config.logdir + '/es_dqm_sourceclient-privlive_cfg.log', 'a')
             log.write('\n\n\n')
-            command = 'source $HOME/DQM.new/cmssw.sh; exec cmsRun {conf} {common}'.format(conf = config.workdir + '/es_dqm_sourceclient-privlive_cfg.py', common = commonOptions)
+            command = 'source $HOME/DQM/cmssw.sh; exec cmsRun {conf} {common}'.format(conf = config.workdir + '/es_dqm_sourceclient-privlive_cfg.py', common = commonOptions)
             proc = subprocess.Popen(command, shell = True, stdout = log, stderr = subprocess.STDOUT)
             logFile.write(command)
             procs['ES'] = (proc, log)
@@ -262,7 +262,7 @@ def writeDB(run, condDB, runParamDB, logFile):
         if 'R%09d'%run in fileName:
             inputFiles += ' inputFiles=' + config.tmpoutdir + '/' + fileName
 
-            command = 'source $HOME/DQM.new/cmssw.sh; exec cmsRun {conf} {inputFiles} {MGPAgain} {runType}'.format(conf = config.workdir + '/writeDB_cfg.py', inputFiles = inputFiles, MGPAgain=MGPAgain, runType=runType)
+            command = 'source $HOME/DQM/cmssw.sh; exec cmsRun {conf} {inputFiles} {MGPAgain} {runType}'.format(conf = config.workdir + '/writeDB_cfg.py', inputFiles = inputFiles, MGPAgain=MGPAgain, runType=runType)
             logFile.write(command)
             log = open(config.logdir + '/dbwrite.log', 'a')
             proc = subprocess.Popen(command, shell = True, stdout = log, stderr = subprocess.STDOUT)

--- a/runOnlineDQM.sh
+++ b/runOnlineDQM.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-source $HOME/DQM.new/cmssw.sh
+source $HOME/DQM/cmssw.sh
 
-python $HOME/DQM.new/p5tools/onlineDQM.py $1 $2
+python $HOME/DQM/p5tools/onlineDQM.py $1 $2


### PR DESCRIPTION
- Move p5tools back to ~ecalpro/DQM/ from temporary ~ecalpro/DQM.new/
- Change ES DQM.collectorHost to new ECAL DQM subsystem machine: fu-c2f11-21-02
- Comment out misleading startDQM():daq == 'central':esIn block in online DQM application. Since we no longer process central DAQ runs, it is misleading to leave this block uncommented since the higher-level processRun() function will never call startDQM() if the run comes from central DAQ
